### PR TITLE
Runtime correctness fixes, test coverage, and micro-optimizations

### DIFF
--- a/lib/protobug/binary_encoding.rb
+++ b/lib/protobug/binary_encoding.rb
@@ -108,6 +108,8 @@ module Protobug
           ((byte1 & 0x7F) << 7) |
           (byte0 & 0x7F)
       elsif (byte9 = binary.getbyte || return) < 0x80
+        raise DecodeError, "varint overflow: 10th byte #{byte9} exceeds 64 bits" if byte9 > 1
+
         (byte9 << 63) |
           ((byte8 & 0x7F) << 56) |
           ((byte7 & 0x7F) << 49) |

--- a/lib/protobug/binary_encoding.rb
+++ b/lib/protobug/binary_encoding.rb
@@ -51,7 +51,7 @@ module Protobug
       outbuf << contents
     end
 
-    def eof!
+    def varint_eof!
       raise EOFError, "unexpected EOF in the middle of a varint"
     end
 
@@ -61,31 +61,31 @@ module Protobug
       # byte is a truncated varint and must be rejected.
       if (byte0 = binary.getbyte || return) < 0x80
         byte0
-      elsif (byte1 = binary.getbyte || eof!) < 0x80
+      elsif (byte1 = binary.getbyte || varint_eof!) < 0x80
         (byte1 << 7) | (byte0 & 0x7F)
-      elsif (byte2 = binary.getbyte || eof!) < 0x80
+      elsif (byte2 = binary.getbyte || varint_eof!) < 0x80
         (byte2 << 14) |
           ((byte1 & 0x7F) << 7) |
           (byte0 & 0x7F)
-      elsif (byte3 = binary.getbyte || eof!) < 0x80
+      elsif (byte3 = binary.getbyte || varint_eof!) < 0x80
         (byte3 << 21) |
           ((byte2 & 0x7F) << 14) |
           ((byte1 & 0x7F) << 7) |
           (byte0 & 0x7F)
-      elsif (byte4 = binary.getbyte || eof!) < 0x80
+      elsif (byte4 = binary.getbyte || varint_eof!) < 0x80
         (byte4 << 28) |
           ((byte3 & 0x7F) << 21) |
           ((byte2 & 0x7F) << 14) |
           ((byte1 & 0x7F) << 7) |
           (byte0 & 0x7F)
-      elsif (byte5 = binary.getbyte || eof!) < 0x80
+      elsif (byte5 = binary.getbyte || varint_eof!) < 0x80
         (byte5 << 35) |
           ((byte4 & 0x7F) << 28) |
           ((byte3 & 0x7F) << 21) |
           ((byte2 & 0x7F) << 14) |
           ((byte1 & 0x7F) << 7) |
           (byte0 & 0x7F)
-      elsif (byte6 = binary.getbyte || eof!) < 0x80
+      elsif (byte6 = binary.getbyte || varint_eof!) < 0x80
         (byte6 << 42) |
           ((byte5 & 0x7F) << 35) |
           ((byte4 & 0x7F) << 28) |
@@ -93,7 +93,7 @@ module Protobug
           ((byte2 & 0x7F) << 14) |
           ((byte1 & 0x7F) << 7) |
           (byte0 & 0x7F)
-      elsif (byte7 = binary.getbyte || eof!) < 0x80
+      elsif (byte7 = binary.getbyte || varint_eof!) < 0x80
         (byte7 << 49) |
           ((byte6 & 0x7F) << 42) |
           ((byte5 & 0x7F) << 35) |
@@ -102,7 +102,7 @@ module Protobug
           ((byte2 & 0x7F) << 14) |
           ((byte1 & 0x7F) << 7) |
           (byte0 & 0x7F)
-      elsif (byte8 = binary.getbyte || eof!) < 0x80
+      elsif (byte8 = binary.getbyte || varint_eof!) < 0x80
         (byte8 << 56) |
           ((byte7 & 0x7F) << 49) |
           ((byte6 & 0x7F) << 42) |
@@ -112,7 +112,7 @@ module Protobug
           ((byte2 & 0x7F) << 14) |
           ((byte1 & 0x7F) << 7) |
           (byte0 & 0x7F)
-      elsif (byte9 = binary.getbyte || eof!) < 0x80
+      elsif (byte9 = binary.getbyte || varint_eof!) < 0x80
         raise DecodeError, "varint overflow: 10th byte #{byte9} exceeds 64 bits" if byte9 > 1
 
         (byte9 << 63) |

--- a/lib/protobug/binary_encoding.rb
+++ b/lib/protobug/binary_encoding.rb
@@ -11,17 +11,15 @@ module Protobug
       raise RangeError, "expected 64-bit integer" if value > (2**64) - 1 || value < -2**63
 
       value += 2**64 if value < 0
-      out = []
       loop do
         if value.bit_length > 7
-          out << (0b1000_0000 | (value & 0b0111_1111))
+          outbuf << (0b1000_0000 | (value & 0b0111_1111))
           value >>= 7
         else
-          out << (value & 0b0111_1111)
+          outbuf << (value & 0b0111_1111)
           break
         end
       end
-      pack(out, "c*", buffer: outbuf)
     end
 
     if RUBY_ENGINE == "truffleruby"

--- a/lib/protobug/binary_encoding.rb
+++ b/lib/protobug/binary_encoding.rb
@@ -53,34 +53,41 @@ module Protobug
       outbuf << contents
     end
 
+    def eof!
+      raise EOFError, "unexpected EOF in the middle of a varint"
+    end
+
     def decode_varint(binary)
+      # Only the first byte may legitimately be absent (clean EOF, signaled by
+      # returning nil). Once a continuation bit is set, any subsequent missing
+      # byte is a truncated varint and must be rejected.
       if (byte0 = binary.getbyte || return) < 0x80
         byte0
-      elsif (byte1 = binary.getbyte || return) < 0x80
+      elsif (byte1 = binary.getbyte || eof!) < 0x80
         (byte1 << 7) | (byte0 & 0x7F)
-      elsif (byte2 = binary.getbyte || return) < 0x80
+      elsif (byte2 = binary.getbyte || eof!) < 0x80
         (byte2 << 14) |
           ((byte1 & 0x7F) << 7) |
           (byte0 & 0x7F)
-      elsif (byte3 = binary.getbyte || return) < 0x80
+      elsif (byte3 = binary.getbyte || eof!) < 0x80
         (byte3 << 21) |
           ((byte2 & 0x7F) << 14) |
           ((byte1 & 0x7F) << 7) |
           (byte0 & 0x7F)
-      elsif (byte4 = binary.getbyte || return) < 0x80
+      elsif (byte4 = binary.getbyte || eof!) < 0x80
         (byte4 << 28) |
           ((byte3 & 0x7F) << 21) |
           ((byte2 & 0x7F) << 14) |
           ((byte1 & 0x7F) << 7) |
           (byte0 & 0x7F)
-      elsif (byte5 = binary.getbyte || return) < 0x80
+      elsif (byte5 = binary.getbyte || eof!) < 0x80
         (byte5 << 35) |
           ((byte4 & 0x7F) << 28) |
           ((byte3 & 0x7F) << 21) |
           ((byte2 & 0x7F) << 14) |
           ((byte1 & 0x7F) << 7) |
           (byte0 & 0x7F)
-      elsif (byte6 = binary.getbyte || return) < 0x80
+      elsif (byte6 = binary.getbyte || eof!) < 0x80
         (byte6 << 42) |
           ((byte5 & 0x7F) << 35) |
           ((byte4 & 0x7F) << 28) |
@@ -88,7 +95,7 @@ module Protobug
           ((byte2 & 0x7F) << 14) |
           ((byte1 & 0x7F) << 7) |
           (byte0 & 0x7F)
-      elsif (byte7 = binary.getbyte || return) < 0x80
+      elsif (byte7 = binary.getbyte || eof!) < 0x80
         (byte7 << 49) |
           ((byte6 & 0x7F) << 42) |
           ((byte5 & 0x7F) << 35) |
@@ -97,7 +104,7 @@ module Protobug
           ((byte2 & 0x7F) << 14) |
           ((byte1 & 0x7F) << 7) |
           (byte0 & 0x7F)
-      elsif (byte8 = binary.getbyte || return) < 0x80
+      elsif (byte8 = binary.getbyte || eof!) < 0x80
         (byte8 << 56) |
           ((byte7 & 0x7F) << 49) |
           ((byte6 & 0x7F) << 42) |
@@ -107,7 +114,7 @@ module Protobug
           ((byte2 & 0x7F) << 14) |
           ((byte1 & 0x7F) << 7) |
           (byte0 & 0x7F)
-      elsif (byte9 = binary.getbyte || return) < 0x80
+      elsif (byte9 = binary.getbyte || eof!) < 0x80
         raise DecodeError, "varint overflow: 10th byte #{byte9} exceeds 64 bits" if byte9 > 1
 
         (byte9 << 63) |

--- a/lib/protobug/enum.rb
+++ b/lib/protobug/enum.rb
@@ -123,8 +123,13 @@ module Protobug
           value == other.value
         when Integer
           value == other
-        when String, Symbol
-          name.to_s == other.to_s
+        when String
+          # name is already a frozen String (see #initialize), so no allocation here.
+          name == other
+        when Symbol
+          # Symbol#name returns the frozen interned string, avoiding the allocation
+          # that Symbol#to_s would incur.
+          name == other.name
         else
           false
         end

--- a/lib/protobug/enum.rb
+++ b/lib/protobug/enum.rb
@@ -126,7 +126,7 @@ module Protobug
         when String, Symbol
           name.to_s == other.to_s
         else
-          raise "expected #{self.class}, got #{other.inspect}"
+          false
         end
       end
 

--- a/lib/protobug/field.rb
+++ b/lib/protobug/field.rb
@@ -884,7 +884,7 @@ module Protobug
           -Float::INFINITY
         when "NaN"
           Float::NAN
-        when /\A-?\d+\z/
+        when /\A-?(?:\d+\.?\d*|\.\d+)(?:[eE][-+]?\d+)?\z/
           Float(value)
         when NilClass
           UNSET

--- a/lib/protobug/field.rb
+++ b/lib/protobug/field.rb
@@ -504,8 +504,10 @@ module Protobug
         when /\A-?\d+\z/
           value = Integer(value)
         when Float
-          value, remainder = value.divmod(1)
+          int, remainder = value.divmod(1)
           raise DecodeError, "expected integer for #{inspect}, got #{value.inspect}" unless remainder == 0
+
+          value = int
         else
           raise DecodeError, "expected integer for #{inspect}, got #{value.inspect}"
         end

--- a/lib/protobug/field.rb
+++ b/lib/protobug/field.rb
@@ -739,7 +739,7 @@ module Protobug
       end
 
       def binary_pack
-        "l"
+        "l<"
       end
     end
 

--- a/lib/protobug/field.rb
+++ b/lib/protobug/field.rb
@@ -641,7 +641,7 @@ module Protobug
       end
 
       def binary_pack
-        "q"
+        "q<"
       end
     end
 

--- a/lib/protobug/field.rb
+++ b/lib/protobug/field.rb
@@ -766,7 +766,7 @@ module Protobug
       end
 
       def validate!(value, message)
-        raise "expected boolean, got #{value.inspect}" unless [true, false].include?(value)
+        raise InvalidValueError.new(message, self, value, "expected boolean") unless [true, false].include?(value)
 
         super(value ? 1 : 0, message)
       end

--- a/lib/protobug/field.rb
+++ b/lib/protobug/field.rb
@@ -619,7 +619,7 @@ module Protobug
       end
 
       def binary_pack
-        "Q"
+        "Q<"
       end
     end
 

--- a/lib/protobug/field.rb
+++ b/lib/protobug/field.rb
@@ -466,15 +466,12 @@ module Protobug
         when :varint
           length_mask = (2**bit_length) - 1
           negative = signed && value & (2**bit_length.pred) != 0
-          # warn negative
-          length_mask >> 1 if signed
           if negative
             value &= length_mask # remove sign bit
 
             # 2's complement
             value ^= length_mask
             value += 1
-            # value &= length_mask
             -value
           else
             value & length_mask

--- a/lib/protobug/field.rb
+++ b/lib/protobug/field.rb
@@ -4,6 +4,8 @@ require_relative "binary_encoding"
 
 module Protobug
   class Field
+    PACKABLE_WIRE_TYPES = [0, 1, 5].freeze
+
     attr_accessor :number, :name, :json_name, :cardinality, :oneof, :ivar, :setter,
                   :adder, :haser, :clearer
 
@@ -144,12 +146,13 @@ module Protobug
     end
 
     def binary_decode(binary, message, registry, wire_type)
-      if repeated? && wire_type == 2 && [0, 1, 5].include?(self.wire_type)
+      own_wire_type = self.wire_type
+      if repeated? && wire_type == 2 && PACKABLE_WIRE_TYPES.include?(own_wire_type)
         len = StringIO.new(BinaryEncoding.decode_length(binary))
         len.binmode
 
-        message.send(adder, binary_decode_one(len, message, registry, self.wire_type)) until len.eof?
-      elsif wire_type != self.wire_type
+        message.send(adder, binary_decode_one(len, message, registry, own_wire_type)) until len.eof?
+      elsif wire_type != own_wire_type
         raise DecodeError, "wrong wire type for #{self}: #{wire_type.inspect}"
       else
         message.send(adder || setter, binary_decode_one(binary, message, registry, wire_type))

--- a/lib/protobug/field.rb
+++ b/lib/protobug/field.rb
@@ -884,7 +884,7 @@ module Protobug
           -Float::INFINITY
         when "NaN"
           Float::NAN
-        when /\A-?(?:\d+\.?\d*|\.\d+)(?:[eE][-+]?\d+)?\z/
+        when /\A-?(?:\d+(?:\.\d+)?|\.\d+)(?:[eE][-+]?\d+)?\z/
           Float(value)
         when NilClass
           UNSET

--- a/lib/protobug/message.rb
+++ b/lib/protobug/message.rb
@@ -157,8 +157,10 @@ module Protobug
       message.unknown_fields.each_with_object(buf) do |(number, wire_type, value), outbuf|
         BinaryEncoding.encode_varint((number << 3) | wire_type, outbuf)
         case wire_type
-        when 0, 5
+        when 0
           BinaryEncoding.encode_varint(value, outbuf)
+        when 1, 5
+          outbuf << value
         when 2
           BinaryEncoding.encode_length(value, outbuf)
         else

--- a/lib/protobug/message.rb
+++ b/lib/protobug/message.rb
@@ -126,7 +126,7 @@ module Protobug
       binary.binmode
       while (header = BinaryEncoding.decode_varint(binary))
         wire_type = header & 0b111
-        number = (header ^ wire_type) >> 3
+        number = header >> 3
 
         unless number > 0
           raise DecodeError,

--- a/lib/protobug/message.rb
+++ b/lib/protobug/message.rb
@@ -251,12 +251,11 @@ module Protobug
 
     module InstanceMethods
       def ==(other)
-        return false unless other.is_a? Protobug::Message::InstanceMethods
+        return false unless other.instance_of?(self.class)
 
-        self.class.full_name == other.class.full_name &&
-          self.class.fields_by_name.all? do |name, _|
-            send(name) == other.send(name)
-          end
+        self.class.fields_by_name.all? do |name, _|
+          send(name) == other.send(name)
+        end
       end
       alias eql? ==
 
@@ -290,7 +289,7 @@ module Protobug
       end
 
       def hash
-        self.class.fields_by_name.map { |name, _| send(name) }.hash
+        [self.class, *self.class.fields_by_name.map { |name, _| send(name) }].hash
       end
 
       def to_text

--- a/lib/protobug/message.rb
+++ b/lib/protobug/message.rb
@@ -251,7 +251,7 @@ module Protobug
 
     module InstanceMethods
       def ==(other)
-        return false unless other.is_a? Protobug::Message
+        return false unless other.is_a? Protobug::Message::InstanceMethods
 
         self.class.full_name == other.class.full_name &&
           self.class.fields_by_name.all? do |name, _|

--- a/lib/protobug/message.rb
+++ b/lib/protobug/message.rb
@@ -289,7 +289,11 @@ module Protobug
       end
 
       def hash
-        [self.class, *self.class.fields_by_name.map { |name, _| send(name) }].hash
+        # Build a single array (map result is mutated in place via unshift) rather
+        # than allocating both the mapped array and a second spread literal.
+        values = self.class.fields_by_name.map { |name, _| send(name) }
+        values.unshift(self.class)
+        values.hash
       end
 
       def to_text

--- a/spec/protobug_spec.rb
+++ b/spec/protobug_spec.rb
@@ -372,6 +372,37 @@ RSpec.describe Protobug do
     end
   end
 
+  it "enforces registry register/fetch invariants" do
+    msg_class = Class.new do
+      extend Protobug::Message
+      self.full_name = "test.RegistryItem"
+      optional 1, :a, type: :string
+    end
+    other_class = Class.new do
+      extend Protobug::Message
+      self.full_name = "test.RegistryItem"
+      optional 1, :a, type: :string
+    end
+
+    registry = Protobug::Registry.new
+
+    aggregate_failures do
+      expect { registry.register("not a descriptor") }
+        .to raise_error(ArgumentError, /expected Protobug::BaseDescriptor/)
+
+      registry.register(msg_class)
+      # idempotent re-registration of the same class does not raise
+      expect { registry.register(msg_class) }.not_to raise_error
+      expect(registry.fetch("test.RegistryItem")).to eq(msg_class)
+
+      # two distinct classes under one full_name conflict
+      expect { registry.register(other_class) }
+        .to raise_error(ArgumentError, /duplicate class/)
+
+      expect { registry.fetch("test.Missing") }.to raise_error(KeyError)
+    end
+  end
+
   it "rejects invalid field definitions" do
     aggregate_failures do
       expect do

--- a/spec/protobug_spec.rb
+++ b/spec/protobug_spec.rb
@@ -268,4 +268,69 @@ RSpec.describe Protobug do
       expect(decoded.nums).to eq([1, 2, 3])
     end
   end
+
+  it "round-trips maps and enums through binary and JSON" do
+    enum = Class.new do
+      extend Protobug::Enum
+      self.full_name = "test.Color"
+      const_set(:RED, new("RED", 0).freeze)
+      const_set(:GREEN, new("GREEN", 1).freeze)
+      const_set(:BLUE, new("BLUE", 2).freeze)
+    end
+    msg_class = Class.new do
+      extend Protobug::Message
+      self.full_name = "test.MapEnum"
+      map 1, :counts, key_type: :string, value_type: :int32
+      optional 2, :color, type: :enum, enum_type: "test.Color", proto3_optional: false
+    end
+    registry = Protobug::Registry.new do |r|
+      r.register(enum)
+      r.register(msg_class)
+    end
+
+    msg = msg_class.new
+    msg.add_counts(msg_class.fields_by_name.fetch("counts").type_lookup(registry).new.tap do |e|
+      e.key = "a"
+      e.value = 5
+    end)
+    msg.color = enum::GREEN
+
+    # binary round-trip
+    encoded = msg_class.encode(msg)
+    decoded = msg_class.decode(StringIO.new(encoded), registry: registry)
+    aggregate_failures do
+      expect(decoded.counts).to eq({ "a" => 5 })
+      expect(decoded.color).to eq(enum::GREEN)
+      expect(decoded.color.to_s).to eq("GREEN")
+    end
+
+    # JSON round-trip: known enum serializes as its name
+    json = msg.to_json
+    parsed = JSON.parse(json)
+    aggregate_failures do
+      expect(parsed["counts"]).to eq({ "a" => 5 })
+      expect(parsed["color"]).to eq("GREEN")
+    end
+    from_json = msg_class.decode_json(json, registry: registry)
+    aggregate_failures do
+      expect(from_json.counts).to eq({ "a" => 5 })
+      expect(from_json.color).to eq(enum::GREEN)
+    end
+
+    # unknown enum wire number is retained and re-emitted as its integer
+    unknown_color_class = Class.new do
+      extend Protobug::Message
+      self.full_name = "test.UnknownColor"
+      optional 2, :color, type: :enum, enum_type: "test.Color", proto3_optional: false
+    end
+    # field 2 (enum, wire 0) carrying value 7, which is not a known Color
+    wire = [(2 << 3) | 0, 7].pack("C*")
+    decoded_unknown = unknown_color_class.decode(StringIO.new(wire), registry: registry)
+    aggregate_failures do
+      expect(decoded_unknown.color).to eq(7)
+      expect(decoded_unknown.to_json).to eq(%({"color":7}))
+      reencoded = unknown_color_class.encode(decoded_unknown)
+      expect(reencoded).to eq(wire)
+    end
+  end
 end

--- a/spec/protobug_spec.rb
+++ b/spec/protobug_spec.rb
@@ -343,6 +343,28 @@ RSpec.describe Protobug do
     end
   end
 
+  it "handles decode_json parse-failure, non-hash, and unknown-field paths" do
+    c = Class.new do
+      extend Protobug::Message
+      self.full_name = "test.JsonErrors"
+      optional 1, :a, type: :string
+    end
+
+    aggregate_failures do
+      expect { c.decode_json("{not valid json", registry: nil) }
+        .to raise_error(Protobug::DecodeError, /JSON failed to parse/)
+
+      expect { c.decode_json("[1, 2, 3]", registry: nil) }
+        .to raise_error(Protobug::DecodeError, /expected hash/)
+
+      expect { c.decode_json(%({"a":"x","nope":1}), registry: nil) }
+        .to raise_error(Protobug::UnknownFieldError, /unknown field "nope"/)
+
+      decoded = c.decode_json(%({"a":"x","nope":1}), registry: nil, ignore_unknown_fields: true)
+      expect(decoded.a).to eq("x")
+    end
+  end
+
   it "compares messages by structural equality" do
     c = Class.new do
       extend Protobug::Message

--- a/spec/protobug_spec.rb
+++ b/spec/protobug_spec.rb
@@ -269,6 +269,34 @@ RSpec.describe Protobug do
     end
   end
 
+  it "binary round-trips double and float fields little-endian" do
+    c = Class.new do
+      extend Protobug::Message
+      self.full_name = "test.DoubleFloat"
+      optional 1, :d, type: :double
+      optional 2, :f, type: :float
+    end
+
+    msg = c.new
+    msg.d = 1.5
+    msg.f = -2.25
+
+    encoded = c.encode(msg)
+    aggregate_failures do
+      # double (field 1, wire 1): tag 0x09 then little-endian IEEE-754 1.5
+      expect(encoded[0, 9]).to eq("\x09\x00\x00\x00\x00\x00\x00\xf8\x3f".b)
+      # float (field 2, wire 5): tag 0x15 then little-endian IEEE-754 -2.25
+      f_idx = encoded.index("\x15".b)
+      expect(encoded[f_idx, 5]).to eq("\x15\x00\x00\x10\xc0".b)
+
+      decoded = c.decode(StringIO.new(encoded), registry: nil)
+      expect(decoded.d).to eq(1.5)
+      expect(decoded.d).to be_a(Float)
+      expect(decoded.f).to eq(-2.25)
+      expect(decoded.f).to be_a(Float)
+    end
+  end
+
   it "preserves unknown fields across binary decode/re-encode" do
     full = Class.new do
       extend Protobug::Message

--- a/spec/protobug_spec.rb
+++ b/spec/protobug_spec.rb
@@ -389,6 +389,11 @@ RSpec.describe Protobug do
       expect(c.decode_json('{"d":"1e3"}', registry: nil).d).to eq(1000.0)
       expect(c.decode_json('{"d":"-2.5e-1"}', registry: nil).d).to eq(-0.25)
       expect(c.decode_json('{"d":"42"}', registry: nil).d).to eq(42.0)
+
+      # a trailing dot with no fractional digits is malformed and must raise
+      # DecodeError rather than leaking ArgumentError from Float("1.")
+      expect { c.decode_json('{"d":"1."}', registry: nil) }
+        .to raise_error(Protobug::DecodeError, /expected float/)
     end
   end
 

--- a/spec/protobug_spec.rb
+++ b/spec/protobug_spec.rb
@@ -391,6 +391,38 @@ RSpec.describe Protobug do
     end
   end
 
+  it "merges repeated occurrences of an embedded message field into one submessage" do
+    inner_class = Class.new do
+      extend Protobug::Message
+      self.full_name = "test.MergeInner"
+      optional 1, :a, type: :string
+      optional 2, :b, type: :string
+    end
+    outer_class = Class.new do
+      extend Protobug::Message
+      self.full_name = "test.MergeOuter"
+      optional 1, :inner, type: :message, message_type: "test.MergeInner"
+    end
+    registry = Protobug::Registry.new do |r|
+      r.register(inner_class)
+      r.register(outer_class)
+    end
+
+    first = outer_class.new
+    first.inner = inner_class.new.tap { |i| i.a = "alpha" }
+    second = outer_class.new
+    second.inner = inner_class.new.tap { |i| i.b = "beta" }
+
+    # concatenated wire bytes: two outer messages each carrying the inner field
+    concatenated = outer_class.encode(first) + outer_class.encode(second)
+    decoded = outer_class.decode(StringIO.new(concatenated), registry: registry)
+
+    aggregate_failures do
+      expect(decoded.inner.a).to eq("alpha")
+      expect(decoded.inner.b).to eq("beta")
+    end
+  end
+
   it "handles decode_json parse-failure, non-hash, and unknown-field paths" do
     c = Class.new do
       extend Protobug::Message

--- a/spec/protobug_spec.rb
+++ b/spec/protobug_spec.rb
@@ -516,6 +516,42 @@ RSpec.describe Protobug do
     end
   end
 
+  it "stringifies non-string scalar map keys in JSON per proto3" do
+    msg_class = Class.new do
+      extend Protobug::Message
+      self.full_name = "test.ScalarKeyMaps"
+      map 1, :by_int, key_type: :int32, value_type: :string
+      map 2, :by_bool, key_type: :bool, value_type: :string
+    end
+    registry = Protobug::Registry.new do |r|
+      r.register(msg_class)
+    end
+
+    msg = msg_class.new
+    msg.add_by_int(msg_class.fields_by_name.fetch("by_int").type_lookup(registry).new.tap do |e|
+      e.key = 5
+      e.value = "five"
+    end)
+    msg.add_by_bool(msg_class.fields_by_name.fetch("by_bool").type_lookup(registry).new.tap do |e|
+      e.key = true
+      e.value = "yes"
+    end)
+
+    parsed = JSON.parse(msg.to_json)
+    aggregate_failures do
+      # proto3 JSON requires map keys to be strings; the int and bool keys
+      # must stringify to "5" and "true" respectively
+      expect(parsed["by_int"]).to eq({ "5" => "five" })
+      expect(parsed["by_bool"]).to eq({ "true" => "yes" })
+    end
+
+    from_json = msg_class.decode_json(msg.to_json, registry: registry)
+    aggregate_failures do
+      expect(from_json.by_int).to eq({ 5 => "five" })
+      expect(from_json.by_bool).to eq({ true => "yes" })
+    end
+  end
+
   it "compares enum values across representations and serializes known and unknown numbers" do
     enum = Class.new do
       extend Protobug::Enum

--- a/spec/protobug_spec.rb
+++ b/spec/protobug_spec.rb
@@ -213,16 +213,20 @@ RSpec.describe Protobug do
       optional 4, :sf32, type: :sfixed32
     end
     msg = c.new
-    msg.f = 3
+    msg.f = 0x0102030405060708
     msg.f32 = 72
     msg.sf64 = -1
     msg.sf32 = 76
     aggregate_failures do
       encoded = c.encode(msg)
-      decoded = c.decode(StringIO.new(encoded), registry: nil)
+      # fixed64 (field 1, wire 1) must be little-endian on the wire regardless of host byte order
+      expect(encoded[0, 9]).to eq("\x09\x08\x07\x06\x05\x04\x03\x02\x01".b)
 
-      expect(decoded.f).to eq(3)
+      decoded = c.decode(StringIO.new(encoded), registry: nil)
+      expect(decoded.f).to eq(0x0102030405060708)
       expect(decoded.f32).to eq(72)
+      expect(decoded.sf64).to eq(-1)
+      expect(decoded.sf32).to eq(76)
     end
   end
 

--- a/spec/protobug_spec.rb
+++ b/spec/protobug_spec.rb
@@ -419,6 +419,42 @@ RSpec.describe Protobug do
     end
   end
 
+  it "compares enum values across representations and serializes known and unknown numbers" do
+    enum = Class.new do
+      extend Protobug::Enum
+      self.full_name = "test.EnumRepr"
+      const_set(:RED, new("RED", 0).freeze)
+      const_set(:GREEN, new("GREEN", 1).freeze)
+    end
+    # Freeze registers the members in @values on Ruby < 3.2 (where the const_added
+    # hook is unavailable), matching how generated enums are finalized.
+    enum.freeze
+
+    green = enum::GREEN
+
+    aggregate_failures do
+      # == across Integer, String, and Symbol forms
+      expect(green).to eq(1)
+      expect(green).to eq("GREEN")
+      expect(green).to eq(:GREEN)
+
+      # == against an arbitrary object raises
+      expect { green == Object.new }.to raise_error(/expected #{enum}/)
+
+      # decode_json_hash of an unknown name raises DecodeError
+      expect { enum.decode_json_hash("MAUVE") }
+        .to raise_error(Protobug::DecodeError, /unknown value/)
+
+      # a known value's as_json returns its name
+      expect(green.as_json).to eq("GREEN")
+
+      # an unknown number round-trips as the integer and renders its placeholder name
+      unknown = enum.decode(99)
+      expect(unknown.as_json).to eq(99)
+      expect(unknown.to_s).to eq("<unknown:99>")
+    end
+  end
+
   it "merges repeated occurrences of an embedded message field into one submessage" do
     inner_class = Class.new do
       extend Protobug::Message

--- a/spec/protobug_spec.rb
+++ b/spec/protobug_spec.rb
@@ -278,6 +278,21 @@ RSpec.describe Protobug do
     end
   end
 
+  it "JSON-decodes double values given as fractional and exponent strings" do
+    c = Class.new do
+      extend Protobug::Message
+      self.full_name = "test.JsonDoubleStrings"
+      optional 1, :d, type: :double
+    end
+
+    aggregate_failures do
+      expect(c.decode_json('{"d":"1.5"}', registry: nil).d).to eq(1.5)
+      expect(c.decode_json('{"d":"1e3"}', registry: nil).d).to eq(1000.0)
+      expect(c.decode_json('{"d":"-2.5e-1"}', registry: nil).d).to eq(-0.25)
+      expect(c.decode_json('{"d":"42"}', registry: nil).d).to eq(42.0)
+    end
+  end
+
   it "round-trips maps and enums through binary and JSON" do
     enum = Class.new do
       extend Protobug::Enum

--- a/spec/protobug_spec.rb
+++ b/spec/protobug_spec.rb
@@ -530,6 +530,21 @@ RSpec.describe Protobug do
     end
   end
 
+  it "JSON-decodes URL-safe base64 bytes back to the raw binary value" do
+    c = Class.new do
+      extend Protobug::Message
+      self.full_name = "test.JsonBytes"
+      optional 1, :bytes, type: :bytes
+    end
+
+    # 0xfb,0xef,0xff -> standard base64 "++//" -> URL-safe alphabet "--__"
+    decoded = c.decode_json(%({"bytes":"--__"}), registry: nil)
+    aggregate_failures do
+      expect(decoded.bytes).to eq("\xfb\xef\xff".b)
+      expect(decoded.bytes.encoding).to eq(Encoding::BINARY)
+    end
+  end
+
   it "reports the input float when JSON-decoding a non-integral number into an integer field" do
     c = Class.new do
       extend Protobug::Message

--- a/spec/protobug_spec.rb
+++ b/spec/protobug_spec.rb
@@ -371,4 +371,31 @@ RSpec.describe Protobug do
       expect(a).not_to eql(b)
     end
   end
+
+  it "rejects invalid field definitions" do
+    aggregate_failures do
+      expect do
+        Class.new do
+          extend Protobug::Message
+          optional 1, :a, type: :string
+          optional 1, :b, type: :string
+        end
+      end.to raise_error(Protobug::DefinitionError, /duplicate field number/)
+
+      expect do
+        Class.new do
+          extend Protobug::Message
+          optional 1, :a, type: :string
+          optional 2, :a, type: :string
+        end
+      end.to raise_error(Protobug::DefinitionError, /duplicate field name/)
+
+      expect do
+        Class.new do
+          extend Protobug::Message
+          optional 1, :a, type: :bogus
+        end
+      end.to raise_error(ArgumentError, /Unknown field type/)
+    end
+  end
 end

--- a/spec/protobug_spec.rb
+++ b/spec/protobug_spec.rb
@@ -293,6 +293,39 @@ RSpec.describe Protobug do
     end
   end
 
+  it "round-trips double NaN and float -Infinity through JSON and coerces integers to Float" do
+    c = Class.new do
+      extend Protobug::Message
+      self.full_name = "test.JsonFloatSpecials"
+      optional 1, :d, type: :double
+      optional 2, :f, type: :float
+    end
+
+    msg = c.new
+    msg.d = Float::NAN
+    msg.f = -Float::INFINITY
+
+    parsed = JSON.parse(msg.to_json)
+    aggregate_failures do
+      expect(parsed["d"]).to eq("NaN")
+      expect(parsed["f"]).to eq("-Infinity")
+    end
+
+    decoded = c.decode_json(msg.to_json, registry: nil)
+    aggregate_failures do
+      expect(decoded.d).to be_nan
+      expect(decoded.f).to eq(-Float::INFINITY)
+    end
+
+    coerced = c.decode_json(%({"d":7,"f":-3}), registry: nil)
+    aggregate_failures do
+      expect(coerced.d).to eq(7.0)
+      expect(coerced.d).to be_a(Float)
+      expect(coerced.f).to eq(-3.0)
+      expect(coerced.f).to be_a(Float)
+    end
+  end
+
   it "round-trips maps and enums through binary and JSON" do
     enum = Class.new do
       extend Protobug::Enum

--- a/spec/protobug_spec.rb
+++ b/spec/protobug_spec.rb
@@ -113,6 +113,22 @@ RSpec.describe Protobug do
     end
   end
 
+  it "rejects a truncated tag varint and still terminates on a clean empty stream" do
+    aggregate_failures do
+      # a tag varint whose continuation bit is set but with no following byte is
+      # truncated mid-varint and must be rejected rather than read as clean EOF
+      expect { test3.decode(StringIO.new("\x80".b), registry: nil) }
+        .to raise_error(EOFError)
+
+      # a longer truncated tag varint is likewise rejected
+      expect { test3.decode(StringIO.new("\x80\x80".b), registry: nil) }
+        .to raise_error(EOFError)
+
+      # an empty stream is a legitimate clean EOF and decodes to an empty message
+      expect(test3.decode(StringIO.new("".b), registry: nil)).to eq(test3.new)
+    end
+  end
+
   it "allows oneofs" do
     c = Class.new do
       extend Protobug::Message

--- a/spec/protobug_spec.rb
+++ b/spec/protobug_spec.rb
@@ -409,6 +409,32 @@ RSpec.describe Protobug do
     end
   end
 
+  it "treats distinct message classes with identical fields as unequal" do
+    klass = lambda do
+      Class.new do
+        extend Protobug::Message
+        optional 1, :a, type: :string
+      end
+    end
+
+    c1 = klass.call
+    c2 = klass.call
+
+    m1 = c1.new
+    m1.a = "x"
+    m2 = c2.new
+    m2.a = "x"
+
+    aggregate_failures do
+      expect(c1.full_name).to be_nil
+      expect(c2.full_name).to be_nil
+      expect(m1).not_to eq(m2)
+      expect(m1).not_to eql(m2)
+      expect(m1.hash).not_to eq(m2.hash)
+      expect({ m1 => 1 }[m2]).to be_nil
+    end
+  end
+
   it "enforces registry register/fetch invariants" do
     msg_class = Class.new do
       extend Protobug::Message

--- a/spec/protobug_spec.rb
+++ b/spec/protobug_spec.rb
@@ -216,7 +216,8 @@ RSpec.describe Protobug do
     msg.f = 0x0102030405060708
     msg.f32 = 72
     msg.sf64 = 0x1122334455667788
-    msg.sf32 = 76
+    # asymmetric negative value distinguishes little-endian "l<" from native-endian "l"
+    msg.sf32 = -0x66554434
     aggregate_failures do
       encoded = c.encode(msg)
       # fixed64 (field 1, wire 1) must be little-endian on the wire regardless of host byte order
@@ -224,12 +225,15 @@ RSpec.describe Protobug do
       # sfixed64 (field 3, wire 1) must also be little-endian; an asymmetric value distinguishes byte order
       sf64_idx = encoded.index("\x19".b)
       expect(encoded[sf64_idx, 9]).to eq("\x19\x88\x77\x66\x55\x44\x33\x22\x11".b)
+      # sfixed32 (field 4, wire 5) must also be little-endian; -0x66554434 is 0x99AABBCC two's complement
+      sf32_idx = encoded.index("\x25".b)
+      expect(encoded[sf32_idx, 5]).to eq("\x25\xCC\xBB\xAA\x99".b)
 
       decoded = c.decode(StringIO.new(encoded), registry: nil)
       expect(decoded.f).to eq(0x0102030405060708)
       expect(decoded.f32).to eq(72)
       expect(decoded.sf64).to eq(0x1122334455667788)
-      expect(decoded.sf32).to eq(76)
+      expect(decoded.sf32).to eq(-0x66554434)
     end
   end
 

--- a/spec/protobug_spec.rb
+++ b/spec/protobug_spec.rb
@@ -451,4 +451,41 @@ RSpec.describe Protobug do
       end.to raise_error(ArgumentError, /Unknown field type/)
     end
   end
+
+  it "validates integer range/type and boolean type on assignment" do
+    msg_class = Class.new do
+      extend Protobug::Message
+      self.full_name = "test.Validation"
+      optional 1, :i32, type: :int32
+      optional 2, :u32, type: :uint32
+      optional 3, :flag, type: :bool
+    end
+    msg = msg_class.new
+
+    aggregate_failures do
+      # int32 boundaries are accepted
+      expect { msg.i32 = (2**31) - 1 }.not_to raise_error
+      expect(msg.i32).to eq((2**31) - 1)
+      expect { msg.i32 = -2**31 }.not_to raise_error
+      expect(msg.i32).to eq(-2**31)
+
+      # one past either boundary is rejected
+      expect { msg.i32 = 2**31 }
+        .to raise_error(Protobug::InvalidValueError, /does not fit/)
+      expect { msg.i32 = (-2**31) - 1 }
+        .to raise_error(Protobug::InvalidValueError, /does not fit/)
+
+      # non-integer is rejected
+      expect { msg.i32 = "5" }
+        .to raise_error(Protobug::InvalidValueError, /expected integer/)
+
+      # uint32 rejects negative values
+      expect { msg.u32 = -1 }
+        .to raise_error(Protobug::InvalidValueError, /does not fit/)
+
+      # bool rejects non-boolean
+      expect { msg.flag = "true" }
+        .to raise_error(Protobug::InvalidValueError, /expected boolean/)
+    end
+  end
 end

--- a/spec/protobug_spec.rb
+++ b/spec/protobug_spec.rb
@@ -85,6 +85,34 @@ RSpec.describe Protobug do
     end.to raise_error(Protobug::DecodeError)
   end
 
+  it "guards encode_varint bounds and surfaces EOF on truncated decodes" do
+    fixed = Class.new do
+      extend Protobug::Message
+      self.full_name = "test.Fixed64Eof"
+      optional 1, :f, type: :fixed64
+    end
+
+    aggregate_failures do
+      # encode_varint range guards: one past the unsigned and signed bounds
+      expect { Protobug::BinaryEncoding.encode_varint(2**64, "".b) }
+        .to raise_error(RangeError, /64-bit integer/)
+      expect { Protobug::BinaryEncoding.encode_varint((-2**63) - 1, "".b) }
+        .to raise_error(RangeError, /64-bit integer/)
+
+      # encode_varint type guard
+      expect { Protobug::BinaryEncoding.encode_varint("5", "".b) }
+        .to raise_error(Protobug::EncodeError, /expected integer/)
+
+      # a varint header (field 1, wire 0) with no value byte hits EOF
+      expect { test3.decode(StringIO.new("\x08".b), registry: nil) }
+        .to raise_error(EOFError)
+
+      # a fixed64 header (field 1, wire 1) with fewer than 8 value bytes hits EOF
+      expect { fixed.decode(StringIO.new("\x09\x01\x02\x03".b), registry: nil) }
+        .to raise_error(EOFError)
+    end
+  end
+
   it "allows oneofs" do
     c = Class.new do
       extend Protobug::Message

--- a/spec/protobug_spec.rb
+++ b/spec/protobug_spec.rb
@@ -215,17 +215,20 @@ RSpec.describe Protobug do
     msg = c.new
     msg.f = 0x0102030405060708
     msg.f32 = 72
-    msg.sf64 = -1
+    msg.sf64 = 0x1122334455667788
     msg.sf32 = 76
     aggregate_failures do
       encoded = c.encode(msg)
       # fixed64 (field 1, wire 1) must be little-endian on the wire regardless of host byte order
       expect(encoded[0, 9]).to eq("\x09\x08\x07\x06\x05\x04\x03\x02\x01".b)
+      # sfixed64 (field 3, wire 1) must also be little-endian; an asymmetric value distinguishes byte order
+      sf64_idx = encoded.index("\x19".b)
+      expect(encoded[sf64_idx, 9]).to eq("\x19\x88\x77\x66\x55\x44\x33\x22\x11".b)
 
       decoded = c.decode(StringIO.new(encoded), registry: nil)
       expect(decoded.f).to eq(0x0102030405060708)
       expect(decoded.f32).to eq(72)
-      expect(decoded.sf64).to eq(-1)
+      expect(decoded.sf64).to eq(0x1122334455667788)
       expect(decoded.sf32).to eq(76)
     end
   end

--- a/spec/protobug_spec.rb
+++ b/spec/protobug_spec.rb
@@ -333,4 +333,33 @@ RSpec.describe Protobug do
       expect(reencoded).to eq(wire)
     end
   end
+
+  it "compares messages by structural equality" do
+    c = Class.new do
+      extend Protobug::Message
+      self.full_name = "test.Equality"
+      optional 1, :a, type: :string
+      optional 2, :b, type: :int32
+    end
+
+    a = c.new
+    a.a = "x"
+    a.b = 5
+
+    b = c.new
+    b.a = "x"
+    b.b = 5
+
+    aggregate_failures do
+      expect(a).to eq(b)
+      expect(a).to eql(b)
+      expect(a.hash).to eq(b.hash)
+    end
+
+    b.b = 6
+    aggregate_failures do
+      expect(a).not_to eq(b)
+      expect(a).not_to eql(b)
+    end
+  end
 end

--- a/spec/protobug_spec.rb
+++ b/spec/protobug_spec.rb
@@ -225,4 +225,47 @@ RSpec.describe Protobug do
       expect(roundtrip.d).to eq(150)
     end
   end
+
+  it "round-trips scalars through JSON" do
+    c = Class.new do
+      extend Protobug::Message
+      self.full_name = "test.JsonScalars"
+      optional 1, :s, type: :string
+      optional 2, :bytes, type: :bytes
+      optional 3, :big, type: :int64
+      optional 4, :d, type: :double
+      repeated 5, :nums, type: :int32
+    end
+
+    msg = c.new
+    msg.s = "héllo"
+    msg.bytes = "\x00\x01\x02\xff".b
+    msg.big = 9_223_372_036_854_775_807
+    msg.d = Float::INFINITY
+    msg.add_nums(1)
+    msg.add_nums(2)
+    msg.add_nums(3)
+
+    json = msg.to_json
+    parsed = JSON.parse(json)
+    aggregate_failures do
+      expect(parsed["s"]).to eq("héllo")
+      expect(parsed["bytes"]).to eq(["\x00\x01\x02\xff".b].pack("m0"))
+      expect(parsed["big"]).to eq("9223372036854775807") # int64 encodes as decimal string
+      expect(parsed["d"]).to eq("Infinity")
+      expect(parsed["nums"]).to eq([1, 2, 3])
+    end
+
+    decoded = c.decode_json(json, registry: nil)
+    aggregate_failures do
+      expect(decoded.s).to eq("héllo")
+      expect(decoded.bytes).to eq("\x00\x01\x02\xff".b)
+      expect(decoded.bytes.encoding).to eq(Encoding::BINARY)
+      expect(decoded.big).to eq(9_223_372_036_854_775_807)
+      expect(decoded.big).to be_a(Integer)
+      expect(decoded.d).to eq(Float::INFINITY)
+      expect(decoded.d).to be_a(Float)
+      expect(decoded.nums).to eq([1, 2, 3])
+    end
+  end
 end

--- a/spec/protobug_spec.rb
+++ b/spec/protobug_spec.rb
@@ -155,6 +155,18 @@ RSpec.describe Protobug do
     expect(msg.x).to eq(:b)
   end
 
+  it "rejects JSON setting two members of the same oneof" do
+    c = Class.new do
+      extend Protobug::Message
+      self.full_name = "test.OneofConflict"
+      optional 1, :a, type: :string, oneof: :x
+      optional 2, :b, type: :int32, oneof: :x
+    end
+
+    expect { c.decode_json(%({"a":"hi","b":3}), registry: nil) }
+      .to raise_error(Protobug::DecodeError, /multiple oneof fields set/)
+  end
+
   it "parses packed field" do
     c = Class.new do
       extend Protobug::Message

--- a/spec/protobug_spec.rb
+++ b/spec/protobug_spec.rb
@@ -188,4 +188,41 @@ RSpec.describe Protobug do
       expect(decoded.f32).to eq(72)
     end
   end
+
+  it "preserves unknown fields across binary decode/re-encode" do
+    full = Class.new do
+      extend Protobug::Message
+      optional 1, :a, type: :string
+      optional 2, :b, type: :fixed32
+      optional 3, :c, type: :fixed64
+      optional 4, :d, type: :int32
+    end
+    partial = Class.new do
+      extend Protobug::Message
+      optional 1, :a, type: :string
+    end
+
+    msg = full.new
+    msg.a = "hello"
+    msg.b = 0x01020304
+    msg.c = 0x0102030405060708
+    msg.d = 150
+    encoded = full.encode(msg)
+
+    decoded = partial.decode(StringIO.new(encoded), registry: nil)
+    aggregate_failures do
+      expect(decoded.a).to eq("hello")
+      # fixed32 (wire 5), fixed64 (wire 1), varint (wire 0) all retained as unknown
+      expect(decoded.unknown_fields.map { |n, w, _| [n, w] }).to eq([[2, 5], [3, 1], [4, 0]])
+    end
+
+    reencoded = partial.encode(decoded)
+    roundtrip = full.decode(StringIO.new(reencoded), registry: nil)
+    aggregate_failures do
+      expect(roundtrip.a).to eq("hello")
+      expect(roundtrip.b).to eq(0x01020304)
+      expect(roundtrip.c).to eq(0x0102030405060708)
+      expect(roundtrip.d).to eq(150)
+    end
+  end
 end

--- a/spec/protobug_spec.rb
+++ b/spec/protobug_spec.rb
@@ -76,6 +76,15 @@ RSpec.describe Protobug do
     end
   end
 
+  it "rejects overlong varints whose 10th byte exceeds 64 bits" do
+    # field 1, varint wire type, then 9 continuation bytes plus a 10th byte
+    # that sets bits above bit 63, which cannot fit in a 64-bit integer.
+    encoded = ("\x08".b + ("\xFF".b * 9) + "\x7F".b)
+    expect do
+      test3.decode(StringIO.new(encoded), registry: nil)
+    end.to raise_error(Protobug::DecodeError)
+  end
+
   it "allows oneofs" do
     c = Class.new do
       extend Protobug::Message

--- a/spec/protobug_spec.rb
+++ b/spec/protobug_spec.rb
@@ -571,8 +571,10 @@ RSpec.describe Protobug do
       expect(green).to eq("GREEN")
       expect(green).to eq(:GREEN)
 
-      # == against an arbitrary object raises
-      expect { green == Object.new }.to raise_error(/expected #{enum}/)
+      # == against an arbitrary object returns false rather than raising
+      expect(green == Object.new).to be(false)
+      expect(green).not_to eq(Object.new)
+      expect([green].include?(Object.new)).to be(false)
 
       # decode_json_hash of an unknown name raises DecodeError
       expect { enum.decode_json_hash("MAUVE") }

--- a/spec/protobug_spec.rb
+++ b/spec/protobug_spec.rb
@@ -168,6 +168,15 @@ RSpec.describe Protobug do
     expect(io).to be_eof
   end
 
+  it "raises EncodeError when encoding the wrong type" do
+    c = Class.new do
+      extend Protobug::Message
+      repeated 6, :f, type: :int32, packed: true
+    end
+
+    expect { c.encode(Object.new) }.to raise_error(Protobug::EncodeError, /expected/)
+  end
+
   it "encodes packed field" do
     c = Class.new do
       extend Protobug::Message

--- a/spec/protobug_spec.rb
+++ b/spec/protobug_spec.rb
@@ -168,6 +168,22 @@ RSpec.describe Protobug do
     expect(io).to be_eof
   end
 
+  it "encodes packed field" do
+    c = Class.new do
+      extend Protobug::Message
+      repeated 6, :f, type: :int32, packed: true
+    end
+
+    msg = c.new
+    [3, 270, 86_942].each { |n| msg.add_f(n) }
+
+    encoded = c.encode(msg)
+    expect(encoded.unpack1("H*")).to eq("3206038e029ea705")
+
+    decoded = c.decode(StringIO.new(encoded), registry: nil)
+    expect(decoded.f).to eq([3, 270, 86_942])
+  end
+
   it "parses sint32 and sint64" do
     msg = test_sint.new
     msg.n32 = 4

--- a/spec/protobug_spec.rb
+++ b/spec/protobug_spec.rb
@@ -563,6 +563,25 @@ RSpec.describe Protobug do
     end
   end
 
+  it "rejects field number 0 and group wire types when binary decoding" do
+    c = Class.new do
+      extend Protobug::Message
+      self.full_name = "test.WireGuards"
+      optional 1, :a, type: :string
+    end
+
+    aggregate_failures do
+      # a leading 0x00 byte decodes as field number 0, wire type 0
+      expect { c.decode(StringIO.new("\x00".b), registry: nil) }
+        .to raise_error(Protobug::DecodeError, /unexpected field number 0/)
+
+      # field 5 (unknown), wire type 3 (group start) is an unsupported feature
+      group_start = [(5 << 3) | 3].pack("C*")
+      expect { c.decode(StringIO.new(group_start), registry: nil) }
+        .to raise_error(Protobug::UnsupportedFeatureError, /group/)
+    end
+  end
+
   it "JSON-decodes URL-safe base64 bytes back to the raw binary value" do
     c = Class.new do
       extend Protobug::Message

--- a/spec/protobug_spec.rb
+++ b/spec/protobug_spec.rb
@@ -488,4 +488,15 @@ RSpec.describe Protobug do
         .to raise_error(Protobug::InvalidValueError, /expected boolean/)
     end
   end
+
+  it "reports the input float when JSON-decoding a non-integral number into an integer field" do
+    c = Class.new do
+      extend Protobug::Message
+      self.full_name = "test.JsonIntFloat"
+      optional 1, :n, type: :int32
+    end
+
+    expect { c.decode_json(%({"n":1.5}), registry: nil) }
+      .to raise_error(Protobug::DecodeError, /got 1\.5/)
+  end
 end

--- a/spec/protobug_spec.rb
+++ b/spec/protobug_spec.rb
@@ -614,6 +614,31 @@ RSpec.describe Protobug do
     end
   end
 
+  it "guards cardinality/type mismatches in the definition DSL" do
+    aggregate_failures do
+      expect do
+        Class.new do
+          extend Protobug::Message
+          optional 1, :a, type: :string, cardinality: :repeated
+        end
+      end.to raise_error(Protobug::DefinitionError, /expected cardinality: :optional, got :repeated/)
+
+      expect do
+        Class.new do
+          extend Protobug::Message
+          repeated 1, :a, type: :string, cardinality: :optional
+        end
+      end.to raise_error(Protobug::DefinitionError, /expected cardinality: :repeated, got :optional/)
+
+      expect do
+        Class.new do
+          extend Protobug::Message
+          map 1, :a, type: :wrong
+        end
+      end.to raise_error(Protobug::DefinitionError, /expected type: :map, got :wrong/)
+    end
+  end
+
   it "treats distinct message classes with identical fields as unequal" do
     klass = lambda do
       Class.new do


### PR DESCRIPTION
Hardens the hand-written runtime core (`lib/protobug/**`) with correctness fixes, substantially more test coverage, and a few allocation cleanups. Scoped to the runtime only — generated `gen/**` and the compiler are untouched.

## Bug fixes
- **`Message#==` always returned `false`** — it was gated on `is_a?(Protobug::Message)`, but `Message` is *extended* onto message classes, so instances never matched. Now gated on `instance_of?(self.class)`, and `#hash` folds in `self.class`, so distinct (incl. anonymous) classes with identical fields compare and hash distinctly.
- **Unknown fixed32/fixed64 fields broke on re-encode** — `read_field_value` returns raw bytes for wire types 1 and 5, but the unknown-field encoder treated wire 5 as a varint and had no case for wire 1, raising `EncodeError` on round-trip. Now the raw bytes are written verbatim.
- **`fixed64`/`sfixed32`/`sfixed64` packed host-endian** (`Q`/`q`/`l`) instead of little-endian — corrupts the wire format on big-endian hosts. Now `Q<`/`q<`/`l<`; encode and decode share `binary_pack`, so the change is symmetric.
- **Overlong varints accepted** — the 10th varint byte may legally only be `0` or `1`; larger values produced >64-bit integers. Now raises `DecodeError`.
- **Truncated tag varint** treated as a clean EOF; now rejected.
- **`IntegerField` JSON error** reported the truncated quotient rather than the offending input (`1.5` -> "got 1"); now reports the original value.
- Float/double JSON string decode accepts fractional/exponent forms (`"1.5"`, `"1e3"`); malformed forms like `"1."` raise `DecodeError`.
- `BoolField#validate!` raises `InvalidValueError` instead of `RuntimeError`; `Enum#==` returns `false` for unrecognized comparands.

## Tests
- rspec examples **7 -> 32**, line coverage **~62% -> ~94%**.
- New coverage across binary encode/decode edge cases, JSON paths, enum/map semantics, registry invariants, and field-definition guards.

## Performance / cleanup
- Hoisted `PACKABLE_WIRE_TYPES` out of the decode hot loop; append varint bytes directly to the output buffer.
- Removed a redundant XOR in field-number extraction and a dead no-op in varint decode.
- `Enum#==` and `Message#hash` avoid transient String/Array allocations.
- Renamed `eof!` -> `varint_eof!` (only called from varint decode).

## Verification
- `rake spec`: 32 examples, 0 failures.
- `rubocop`: clean.
- `rake conformance`: 2580 successes, 10 skipped, 15 expected failures, **0 unexpected failures** (full binary+JSON suite; the 120 text-format tests are skipped as before).