### PR TITLE
Bump version to 0.2.0 and update CHANGELOG

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,30 @@
 ## [Unreleased]
 
+## [0.2.0] - 2026-06-18
+
+### Added
+
+- New compiled proto gems: `protobug_fulcio_protos`, `protobug_googleapis_annotations_protos`,
+  `protobug_in_toto_attestation_protos`, and `protobug_protoc_gen_openapiv2_protos`.
+- Bump sigstore protobuf-specs to v0.5.1, adding `SigningConfig` v0.2 along with the
+  `Service`, `ServiceSelector`, and `ServiceConfiguration` messages.
+- Significantly expanded test coverage.
+
+### Fixed
+
+- Decode a truncated varint as an error (`EOFError`) instead of silently returning `nil`,
+  and reject varints whose 10th byte overflows 64 bits.
+- Encode fixed-width integers (`fixed64`/`sfixed64`/`sfixed32`) in little-endian order,
+  correcting the binary wire format on big-endian hosts.
+- Re-encode unknown fields of wire types 1 and 5 as raw bytes rather than varints.
+- Raise a structured `InvalidValueError` on invalid boolean values.
+- Accept decimal and exponent notation when parsing floats from JSON.
+
+### Changed
+
+- Generate message field accessors via `class_eval` rather than `define_method` closures.
+- `Enum#==` returns `false` for unrecognized operand types instead of raising.
+
 ## [0.1.0] - 2024-02-21
 
 - Initial release

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,52 +1,52 @@
 PATH
   remote: .
   specs:
-    protobug (0.1.1)
+    protobug (0.2.0)
 
 PATH
   remote: gen/protobug_compiler_protos
   specs:
-    protobug_compiler_protos (0.1.1)
-      protobug (= 0.1.1)
-      protobug_well_known_protos (= 0.1.1)
+    protobug_compiler_protos (0.2.0)
+      protobug (= 0.2.0)
+      protobug_well_known_protos (= 0.2.0)
 
 PATH
   remote: gen/protobug_conformance_protos
   specs:
-    protobug_conformance_protos (0.1.1)
-      protobug (= 0.1.1)
-      protobug_well_known_protos (= 0.1.1)
+    protobug_conformance_protos (0.2.0)
+      protobug (= 0.2.0)
+      protobug_well_known_protos (= 0.2.0)
 
 PATH
   remote: gen/protobug_googleapis_field_behavior_protos
   specs:
-    protobug_googleapis_field_behavior_protos (0.1.1)
-      protobug (= 0.1.1)
-      protobug_well_known_protos (= 0.1.1)
+    protobug_googleapis_field_behavior_protos (0.2.0)
+      protobug (= 0.2.0)
+      protobug_well_known_protos (= 0.2.0)
 
 PATH
   remote: gen/protobug_sigstore_protos
   specs:
-    protobug_sigstore_protos (0.1.1)
-      protobug (= 0.1.1)
-      protobug_googleapis_field_behavior_protos (= 0.1.1)
-      protobug_well_known_protos (= 0.1.1)
+    protobug_sigstore_protos (0.2.0)
+      protobug (= 0.2.0)
+      protobug_googleapis_field_behavior_protos (= 0.2.0)
+      protobug_well_known_protos (= 0.2.0)
 
 PATH
   remote: gen/protobug_well_known_protos
   specs:
-    protobug_well_known_protos (0.1.1)
-      protobug (= 0.1.1)
+    protobug_well_known_protos (0.2.0)
+      protobug (= 0.2.0)
 
 PATH
   remote: protobug-compiler
   specs:
-    protobug-compiler (0.1.1)
+    protobug-compiler (0.2.0)
       delegate
       forwardable
       prettier_print (~> 1.2, >= 1.2.1)
-      protobug (= 0.1.1)
-      protobug_compiler_protos (= 0.1.1)
+      protobug (= 0.2.0)
+      protobug_compiler_protos (= 0.2.0)
 
 GEM
   remote: https://rubygems.org/

--- a/gen/protobug_compiler_protos/protobug_compiler_protos.gemspec
+++ b/gen/protobug_compiler_protos/protobug_compiler_protos.gemspec
@@ -1,9 +1,9 @@
 # -*- encoding: utf-8 -*-
-# stub: protobug_compiler_protos 0.1.1 ruby lib
+# stub: protobug_compiler_protos 0.2.0 ruby lib
 
 Gem::Specification.new do |s|
   s.name = "protobug_compiler_protos".freeze
-  s.version = "0.1.1".freeze
+  s.version = "0.2.0".freeze
 
   s.required_rubygems_version = Gem::Requirement.new(">= 0".freeze) if s.respond_to? :required_rubygems_version=
   s.metadata = { "rubygems_mfa_required" => "true" } if s.respond_to? :metadata=
@@ -12,7 +12,7 @@ Gem::Specification.new do |s|
 
   s.email = ["segiddins@segiddins.me".freeze]
   s.files = ["lib/google/protobuf/compiler/plugin_pb.rb".freeze, "lib/protobug_compiler_protos.rb".freeze]
-  s.homepage = "https://github.com/segiddins/protobug/blob/v0.1.1/gen/protobug_compiler_protos".freeze
+  s.homepage = "https://github.com/segiddins/protobug/blob/v0.2.0/gen/protobug_compiler_protos".freeze
   s.licenses = ["Unlicense".freeze]
   s.required_ruby_version = Gem::Requirement.new(">= 3.0.0".freeze)
 
@@ -20,6 +20,6 @@ Gem::Specification.new do |s|
 
   s.specification_version = 4
 
-  s.add_runtime_dependency(%q<protobug>.freeze, ["= 0.1.1".freeze])
-  s.add_runtime_dependency(%q<protobug_well_known_protos>.freeze, ["= 0.1.1".freeze])
+  s.add_runtime_dependency(%q<protobug>.freeze, ["= 0.2.0".freeze])
+  s.add_runtime_dependency(%q<protobug_well_known_protos>.freeze, ["= 0.2.0".freeze])
 end

--- a/gen/protobug_conformance_protos/protobug_conformance_protos.gemspec
+++ b/gen/protobug_conformance_protos/protobug_conformance_protos.gemspec
@@ -1,9 +1,9 @@
 # -*- encoding: utf-8 -*-
-# stub: protobug_conformance_protos 0.1.1 ruby lib
+# stub: protobug_conformance_protos 0.2.0 ruby lib
 
 Gem::Specification.new do |s|
   s.name = "protobug_conformance_protos".freeze
-  s.version = "0.1.1".freeze
+  s.version = "0.2.0".freeze
 
   s.required_rubygems_version = Gem::Requirement.new(">= 0".freeze) if s.respond_to? :required_rubygems_version=
   s.metadata = { "rubygems_mfa_required" => "true" } if s.respond_to? :metadata=
@@ -12,7 +12,7 @@ Gem::Specification.new do |s|
 
   s.email = ["segiddins@segiddins.me".freeze]
   s.files = ["lib/conformance/conformance_pb.rb".freeze, "lib/protobuf_test_messages/proto2/test_messages_proto2_pb.rb".freeze, "lib/protobuf_test_messages/proto3/test_messages_proto3_pb.rb".freeze, "lib/protobug_conformance_protos.rb".freeze]
-  s.homepage = "https://github.com/segiddins/protobug/blob/v0.1.1/gen/protobug_conformance_protos".freeze
+  s.homepage = "https://github.com/segiddins/protobug/blob/v0.2.0/gen/protobug_conformance_protos".freeze
   s.licenses = ["Unlicense".freeze]
   s.required_ruby_version = Gem::Requirement.new(">= 3.0.0".freeze)
 
@@ -20,6 +20,6 @@ Gem::Specification.new do |s|
 
   s.specification_version = 4
 
-  s.add_runtime_dependency(%q<protobug>.freeze, ["= 0.1.1".freeze])
-  s.add_runtime_dependency(%q<protobug_well_known_protos>.freeze, ["= 0.1.1".freeze])
+  s.add_runtime_dependency(%q<protobug>.freeze, ["= 0.2.0".freeze])
+  s.add_runtime_dependency(%q<protobug_well_known_protos>.freeze, ["= 0.2.0".freeze])
 end

--- a/gen/protobug_fulcio_protos/protobug_fulcio_protos.gemspec
+++ b/gen/protobug_fulcio_protos/protobug_fulcio_protos.gemspec
@@ -1,9 +1,9 @@
 # -*- encoding: utf-8 -*-
-# stub: protobug_fulcio_protos 0.1.1 ruby lib
+# stub: protobug_fulcio_protos 0.2.0 ruby lib
 
 Gem::Specification.new do |s|
   s.name = "protobug_fulcio_protos".freeze
-  s.version = "0.1.1".freeze
+  s.version = "0.2.0".freeze
 
   s.required_rubygems_version = Gem::Requirement.new(">= 0".freeze) if s.respond_to? :required_rubygems_version=
   s.metadata = { "rubygems_mfa_required" => "true" } if s.respond_to? :metadata=
@@ -12,7 +12,7 @@ Gem::Specification.new do |s|
 
   s.email = ["segiddins@segiddins.me".freeze]
   s.files = ["lib/dev/sigstore/fulcio/v2/fulcio_pb.rb".freeze, "lib/protobug_fulcio_protos.rb".freeze]
-  s.homepage = "https://github.com/segiddins/protobug/blob/v0.1.1/gen/protobug_fulcio_protos".freeze
+  s.homepage = "https://github.com/segiddins/protobug/blob/v0.2.0/gen/protobug_fulcio_protos".freeze
   s.licenses = ["Unlicense".freeze]
   s.required_ruby_version = Gem::Requirement.new(">= 3.0.0".freeze)
 
@@ -20,9 +20,9 @@ Gem::Specification.new do |s|
 
   s.specification_version = 4
 
-  s.add_runtime_dependency(%q<protobug>.freeze, ["= 0.1.1".freeze])
-  s.add_runtime_dependency(%q<protobug_well_known_protos>.freeze, ["= 0.1.1".freeze])
-  s.add_runtime_dependency(%q<protobug_googleapis_field_behavior_protos>.freeze, ["= 0.1.1".freeze])
-  s.add_runtime_dependency(%q<protobug_googleapis_annotations_protos>.freeze, ["= 0.1.1".freeze])
-  s.add_runtime_dependency(%q<protobug_protoc_gen_openapiv2_protos>.freeze, ["= 0.1.1".freeze])
+  s.add_runtime_dependency(%q<protobug>.freeze, ["= 0.2.0".freeze])
+  s.add_runtime_dependency(%q<protobug_well_known_protos>.freeze, ["= 0.2.0".freeze])
+  s.add_runtime_dependency(%q<protobug_googleapis_field_behavior_protos>.freeze, ["= 0.2.0".freeze])
+  s.add_runtime_dependency(%q<protobug_googleapis_annotations_protos>.freeze, ["= 0.2.0".freeze])
+  s.add_runtime_dependency(%q<protobug_protoc_gen_openapiv2_protos>.freeze, ["= 0.2.0".freeze])
 end

--- a/gen/protobug_googleapis_annotations_protos/protobug_googleapis_annotations_protos.gemspec
+++ b/gen/protobug_googleapis_annotations_protos/protobug_googleapis_annotations_protos.gemspec
@@ -1,9 +1,9 @@
 # -*- encoding: utf-8 -*-
-# stub: protobug_googleapis_annotations_protos 0.1.1 ruby lib
+# stub: protobug_googleapis_annotations_protos 0.2.0 ruby lib
 
 Gem::Specification.new do |s|
   s.name = "protobug_googleapis_annotations_protos".freeze
-  s.version = "0.1.1".freeze
+  s.version = "0.2.0".freeze
 
   s.required_rubygems_version = Gem::Requirement.new(">= 0".freeze) if s.respond_to? :required_rubygems_version=
   s.metadata = { "rubygems_mfa_required" => "true" } if s.respond_to? :metadata=
@@ -12,7 +12,7 @@ Gem::Specification.new do |s|
 
   s.email = ["segiddins@segiddins.me".freeze]
   s.files = ["lib/google/api/annotations_pb.rb".freeze, "lib/google/api/http_pb.rb".freeze, "lib/protobug_googleapis_annotations_protos.rb".freeze]
-  s.homepage = "https://github.com/segiddins/protobug/blob/v0.1.1/gen/protobug_googleapis_annotations_protos".freeze
+  s.homepage = "https://github.com/segiddins/protobug/blob/v0.2.0/gen/protobug_googleapis_annotations_protos".freeze
   s.licenses = ["Unlicense".freeze]
   s.required_ruby_version = Gem::Requirement.new(">= 3.0.0".freeze)
 
@@ -20,6 +20,6 @@ Gem::Specification.new do |s|
 
   s.specification_version = 4
 
-  s.add_runtime_dependency(%q<protobug>.freeze, ["= 0.1.1".freeze])
-  s.add_runtime_dependency(%q<protobug_well_known_protos>.freeze, ["= 0.1.1".freeze])
+  s.add_runtime_dependency(%q<protobug>.freeze, ["= 0.2.0".freeze])
+  s.add_runtime_dependency(%q<protobug_well_known_protos>.freeze, ["= 0.2.0".freeze])
 end

--- a/gen/protobug_googleapis_field_behavior_protos/protobug_googleapis_field_behavior_protos.gemspec
+++ b/gen/protobug_googleapis_field_behavior_protos/protobug_googleapis_field_behavior_protos.gemspec
@@ -1,9 +1,9 @@
 # -*- encoding: utf-8 -*-
-# stub: protobug_googleapis_field_behavior_protos 0.1.1 ruby lib
+# stub: protobug_googleapis_field_behavior_protos 0.2.0 ruby lib
 
 Gem::Specification.new do |s|
   s.name = "protobug_googleapis_field_behavior_protos".freeze
-  s.version = "0.1.1".freeze
+  s.version = "0.2.0".freeze
 
   s.required_rubygems_version = Gem::Requirement.new(">= 0".freeze) if s.respond_to? :required_rubygems_version=
   s.metadata = { "rubygems_mfa_required" => "true" } if s.respond_to? :metadata=
@@ -12,7 +12,7 @@ Gem::Specification.new do |s|
 
   s.email = ["segiddins@segiddins.me".freeze]
   s.files = ["lib/google/api/field_behavior_pb.rb".freeze, "lib/protobug_googleapis_field_behavior_protos.rb".freeze]
-  s.homepage = "https://github.com/segiddins/protobug/blob/v0.1.1/gen/protobug_googleapis_field_behavior_protos".freeze
+  s.homepage = "https://github.com/segiddins/protobug/blob/v0.2.0/gen/protobug_googleapis_field_behavior_protos".freeze
   s.licenses = ["Unlicense".freeze]
   s.required_ruby_version = Gem::Requirement.new(">= 3.0.0".freeze)
 
@@ -20,6 +20,6 @@ Gem::Specification.new do |s|
 
   s.specification_version = 4
 
-  s.add_runtime_dependency(%q<protobug>.freeze, ["= 0.1.1".freeze])
-  s.add_runtime_dependency(%q<protobug_well_known_protos>.freeze, ["= 0.1.1".freeze])
+  s.add_runtime_dependency(%q<protobug>.freeze, ["= 0.2.0".freeze])
+  s.add_runtime_dependency(%q<protobug_well_known_protos>.freeze, ["= 0.2.0".freeze])
 end

--- a/gen/protobug_in_toto_attestation_protos/protobug_in_toto_attestation_protos.gemspec
+++ b/gen/protobug_in_toto_attestation_protos/protobug_in_toto_attestation_protos.gemspec
@@ -1,9 +1,9 @@
 # -*- encoding: utf-8 -*-
-# stub: protobug_in_toto_attestation_protos 0.1.1 ruby lib
+# stub: protobug_in_toto_attestation_protos 0.2.0 ruby lib
 
 Gem::Specification.new do |s|
   s.name = "protobug_in_toto_attestation_protos".freeze
-  s.version = "0.1.1".freeze
+  s.version = "0.2.0".freeze
 
   s.required_rubygems_version = Gem::Requirement.new(">= 0".freeze) if s.respond_to? :required_rubygems_version=
   s.metadata = { "rubygems_mfa_required" => "true" } if s.respond_to? :metadata=
@@ -12,7 +12,7 @@ Gem::Specification.new do |s|
 
   s.email = ["segiddins@segiddins.me".freeze]
   s.files = ["lib/in_toto_attestation/predicates/link/v0/link_pb.rb".freeze, "lib/in_toto_attestation/predicates/provenance/v1/provenance_pb.rb".freeze, "lib/in_toto_attestation/predicates/release/v0/release_pb.rb".freeze, "lib/in_toto_attestation/predicates/scai/v0/scai_pb.rb".freeze, "lib/in_toto_attestation/predicates/test_result/v0/test_result_pb.rb".freeze, "lib/in_toto_attestation/predicates/vsa/v0/vsa_pb.rb".freeze, "lib/in_toto_attestation/predicates/vsa/v1/vsa_pb.rb".freeze, "lib/in_toto_attestation/v1/resource_descriptor_pb.rb".freeze, "lib/in_toto_attestation/v1/statement_pb.rb".freeze, "lib/protobug_in_toto_attestation_protos.rb".freeze]
-  s.homepage = "https://github.com/segiddins/protobug/blob/v0.1.1/gen/protobug_in_toto_attestation_protos".freeze
+  s.homepage = "https://github.com/segiddins/protobug/blob/v0.2.0/gen/protobug_in_toto_attestation_protos".freeze
   s.licenses = ["Unlicense".freeze]
   s.required_ruby_version = Gem::Requirement.new(">= 3.0.0".freeze)
 
@@ -20,6 +20,6 @@ Gem::Specification.new do |s|
 
   s.specification_version = 4
 
-  s.add_runtime_dependency(%q<protobug>.freeze, ["= 0.1.1".freeze])
-  s.add_runtime_dependency(%q<protobug_well_known_protos>.freeze, ["= 0.1.1".freeze])
+  s.add_runtime_dependency(%q<protobug>.freeze, ["= 0.2.0".freeze])
+  s.add_runtime_dependency(%q<protobug_well_known_protos>.freeze, ["= 0.2.0".freeze])
 end

--- a/gen/protobug_protoc_gen_openapiv2_protos/protobug_protoc_gen_openapiv2_protos.gemspec
+++ b/gen/protobug_protoc_gen_openapiv2_protos/protobug_protoc_gen_openapiv2_protos.gemspec
@@ -1,9 +1,9 @@
 # -*- encoding: utf-8 -*-
-# stub: protobug_protoc_gen_openapiv2_protos 0.1.1 ruby lib
+# stub: protobug_protoc_gen_openapiv2_protos 0.2.0 ruby lib
 
 Gem::Specification.new do |s|
   s.name = "protobug_protoc_gen_openapiv2_protos".freeze
-  s.version = "0.1.1".freeze
+  s.version = "0.2.0".freeze
 
   s.required_rubygems_version = Gem::Requirement.new(">= 0".freeze) if s.respond_to? :required_rubygems_version=
   s.metadata = { "rubygems_mfa_required" => "true" } if s.respond_to? :metadata=
@@ -12,7 +12,7 @@ Gem::Specification.new do |s|
 
   s.email = ["segiddins@segiddins.me".freeze]
   s.files = ["lib/grpc/gateway/protoc_gen_openapiv2/options/annotations_pb.rb".freeze, "lib/grpc/gateway/protoc_gen_openapiv2/options/openapiv2_pb.rb".freeze, "lib/protobug_protoc_gen_openapiv2_protos.rb".freeze]
-  s.homepage = "https://github.com/segiddins/protobug/blob/v0.1.1/gen/protobug_protoc_gen_openapiv2_protos".freeze
+  s.homepage = "https://github.com/segiddins/protobug/blob/v0.2.0/gen/protobug_protoc_gen_openapiv2_protos".freeze
   s.licenses = ["Unlicense".freeze]
   s.required_ruby_version = Gem::Requirement.new(">= 3.0.0".freeze)
 
@@ -20,7 +20,7 @@ Gem::Specification.new do |s|
 
   s.specification_version = 4
 
-  s.add_runtime_dependency(%q<protobug>.freeze, ["= 0.1.1".freeze])
-  s.add_runtime_dependency(%q<protobug_well_known_protos>.freeze, ["= 0.1.1".freeze])
-  s.add_runtime_dependency(%q<protobug_googleapis_field_behavior_protos>.freeze, ["= 0.1.1".freeze])
+  s.add_runtime_dependency(%q<protobug>.freeze, ["= 0.2.0".freeze])
+  s.add_runtime_dependency(%q<protobug_well_known_protos>.freeze, ["= 0.2.0".freeze])
+  s.add_runtime_dependency(%q<protobug_googleapis_field_behavior_protos>.freeze, ["= 0.2.0".freeze])
 end

--- a/gen/protobug_sigstore_protos/protobug_sigstore_protos.gemspec
+++ b/gen/protobug_sigstore_protos/protobug_sigstore_protos.gemspec
@@ -1,9 +1,9 @@
 # -*- encoding: utf-8 -*-
-# stub: protobug_sigstore_protos 0.1.1 ruby lib
+# stub: protobug_sigstore_protos 0.2.0 ruby lib
 
 Gem::Specification.new do |s|
   s.name = "protobug_sigstore_protos".freeze
-  s.version = "0.1.1".freeze
+  s.version = "0.2.0".freeze
 
   s.required_rubygems_version = Gem::Requirement.new(">= 0".freeze) if s.respond_to? :required_rubygems_version=
   s.metadata = { "rubygems_mfa_required" => "true" } if s.respond_to? :metadata=
@@ -12,7 +12,7 @@ Gem::Specification.new do |s|
 
   s.email = ["segiddins@segiddins.me".freeze]
   s.files = ["lib/protobug_sigstore_protos.rb".freeze, "lib/sigstore/bundle/v1/sigstore_bundle_pb.rb".freeze, "lib/sigstore/common/v1/sigstore_common_pb.rb".freeze, "lib/sigstore/dsse/envelope_pb.rb".freeze, "lib/sigstore/events/events_pb.rb".freeze, "lib/sigstore/rekor/v1/sigstore_rekor_pb.rb".freeze, "lib/sigstore/trustroot/v1/sigstore_trustroot_pb.rb".freeze, "lib/sigstore/verification/v1/sigstore_verification_pb.rb".freeze]
-  s.homepage = "https://github.com/segiddins/protobug/blob/v0.1.1/gen/protobug_sigstore_protos".freeze
+  s.homepage = "https://github.com/segiddins/protobug/blob/v0.2.0/gen/protobug_sigstore_protos".freeze
   s.licenses = ["Unlicense".freeze]
   s.required_ruby_version = Gem::Requirement.new(">= 3.0.0".freeze)
 
@@ -20,7 +20,7 @@ Gem::Specification.new do |s|
 
   s.specification_version = 4
 
-  s.add_runtime_dependency(%q<protobug>.freeze, ["= 0.1.1".freeze])
-  s.add_runtime_dependency(%q<protobug_well_known_protos>.freeze, ["= 0.1.1".freeze])
-  s.add_runtime_dependency(%q<protobug_googleapis_field_behavior_protos>.freeze, ["= 0.1.1".freeze])
+  s.add_runtime_dependency(%q<protobug>.freeze, ["= 0.2.0".freeze])
+  s.add_runtime_dependency(%q<protobug_well_known_protos>.freeze, ["= 0.2.0".freeze])
+  s.add_runtime_dependency(%q<protobug_googleapis_field_behavior_protos>.freeze, ["= 0.2.0".freeze])
 end

--- a/gen/protobug_well_known_protos/protobug_well_known_protos.gemspec
+++ b/gen/protobug_well_known_protos/protobug_well_known_protos.gemspec
@@ -1,9 +1,9 @@
 # -*- encoding: utf-8 -*-
-# stub: protobug_well_known_protos 0.1.1 ruby lib
+# stub: protobug_well_known_protos 0.2.0 ruby lib
 
 Gem::Specification.new do |s|
   s.name = "protobug_well_known_protos".freeze
-  s.version = "0.1.1".freeze
+  s.version = "0.2.0".freeze
 
   s.required_rubygems_version = Gem::Requirement.new(">= 0".freeze) if s.respond_to? :required_rubygems_version=
   s.metadata = { "rubygems_mfa_required" => "true" } if s.respond_to? :metadata=
@@ -12,7 +12,7 @@ Gem::Specification.new do |s|
 
   s.email = ["segiddins@segiddins.me".freeze]
   s.files = ["lib/google/protobuf/any_pb.rb".freeze, "lib/google/protobuf/any_well_known.rb".freeze, "lib/google/protobuf/api_pb.rb".freeze, "lib/google/protobuf/descriptor_pb.rb".freeze, "lib/google/protobuf/duration_pb.rb".freeze, "lib/google/protobuf/duration_well_known.rb".freeze, "lib/google/protobuf/empty_pb.rb".freeze, "lib/google/protobuf/field_mask_pb.rb".freeze, "lib/google/protobuf/field_mask_well_known.rb".freeze, "lib/google/protobuf/source_context_pb.rb".freeze, "lib/google/protobuf/struct_pb.rb".freeze, "lib/google/protobuf/struct_well_known.rb".freeze, "lib/google/protobuf/timestamp_pb.rb".freeze, "lib/google/protobuf/timestamp_well_known.rb".freeze, "lib/google/protobuf/type_pb.rb".freeze, "lib/google/protobuf/wrappers_pb.rb".freeze, "lib/google/protobuf/wrappers_well_known.rb".freeze, "lib/protobug_well_known_protos.rb".freeze]
-  s.homepage = "https://github.com/segiddins/protobug/blob/v0.1.1/gen/protobug_well_known_protos".freeze
+  s.homepage = "https://github.com/segiddins/protobug/blob/v0.2.0/gen/protobug_well_known_protos".freeze
   s.licenses = ["Unlicense".freeze]
   s.required_ruby_version = Gem::Requirement.new(">= 3.0.0".freeze)
 
@@ -20,5 +20,5 @@ Gem::Specification.new do |s|
 
   s.specification_version = 4
 
-  s.add_runtime_dependency(%q<protobug>.freeze, ["= 0.1.1".freeze])
+  s.add_runtime_dependency(%q<protobug>.freeze, ["= 0.2.0".freeze])
 end

--- a/lib/protobug/version.rb
+++ b/lib/protobug/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module Protobug
-  VERSION = "0.1.1"
+  VERSION = "0.2.0"
 end


### PR DESCRIPTION
Bumps `Protobug::VERSION` from `0.1.1` (never released) to `0.2.0` and adds a CHANGELOG entry covering everything accumulated since the last version bump (#22). Releasing requires pushing a `v0.2.0` tag, which triggers `release.yml` to publish the core `protobug` gem plus all `protobug_*_protos` gems together.

Chose `0.2.0` over the dangling `0.1.1` because this release ships four new proto gems and binary wire-format fixes.

## Changes
- `lib/protobug/version.rb`: `0.1.1` → `0.2.0`
- `CHANGELOG.md`: new `0.2.0` section
- Regenerated all 9 proto gemspecs to `0.2.0` (version, homepage, and exact `= 0.2.0` dependency pins) and updated `Gemfile.lock`

## CHANGELOG highlights
**Added**
- New proto gems: `protobug_fulcio_protos`, `protobug_googleapis_annotations_protos`, `protobug_in_toto_attestation_protos`, `protobug_protoc_gen_openapiv2_protos`
- sigstore protobuf-specs bumped to v0.5.1 (SigningConfig v0.2 + `Service`/`ServiceSelector`/`ServiceConfiguration`)
- Significantly expanded test coverage

**Fixed**
- Truncated varints now raise `EOFError` instead of returning `nil`; 10th-byte 64-bit overflow rejected
- Fixed-width integers encoded little-endian (wire-format correctness on big-endian hosts)
- Unknown fields of wire types 1 and 5 re-encoded as raw bytes
- Structured `InvalidValueError` on invalid booleans
- JSON float parsing accepts decimal/exponent notation

**Changed**
- Field accessors generated via `class_eval` instead of `define_method` closures
- `Enum#==` returns `false` for unrecognized operand types instead of raising

## Verification
- `rake verify_proto_gems` — all proto gems build under `gem build --strict` at `0.2.0`
- `rake build` — core gems build at `0.2.0`

🤖 Generated with [Claude Code](https://claude.com/claude-code)