### PR TITLE
Add new proto gems to Gemfile so they publish in 0.2.0

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -8,8 +8,12 @@ gemspec path: "protobug-compiler"
 gemspec path: "gen/protobug_compiler_protos"
 gemspec path: "gen/protobug_conformance_protos"
 gemspec path: "gen/protobug_googleapis_field_behavior_protos"
+gemspec path: "gen/protobug_googleapis_annotations_protos"
 gemspec path: "gen/protobug_well_known_protos"
 gemspec path: "gen/protobug_sigstore_protos"
+gemspec path: "gen/protobug_protoc_gen_openapiv2_protos"
+gemspec path: "gen/protobug_fulcio_protos"
+gemspec path: "gen/protobug_in_toto_attestation_protos"
 
 gem "rake", "~> 13.2"
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -18,10 +18,42 @@ PATH
       protobug_well_known_protos (= 0.2.0)
 
 PATH
+  remote: gen/protobug_fulcio_protos
+  specs:
+    protobug_fulcio_protos (0.2.0)
+      protobug (= 0.2.0)
+      protobug_googleapis_annotations_protos (= 0.2.0)
+      protobug_googleapis_field_behavior_protos (= 0.2.0)
+      protobug_protoc_gen_openapiv2_protos (= 0.2.0)
+      protobug_well_known_protos (= 0.2.0)
+
+PATH
+  remote: gen/protobug_googleapis_annotations_protos
+  specs:
+    protobug_googleapis_annotations_protos (0.2.0)
+      protobug (= 0.2.0)
+      protobug_well_known_protos (= 0.2.0)
+
+PATH
   remote: gen/protobug_googleapis_field_behavior_protos
   specs:
     protobug_googleapis_field_behavior_protos (0.2.0)
       protobug (= 0.2.0)
+      protobug_well_known_protos (= 0.2.0)
+
+PATH
+  remote: gen/protobug_in_toto_attestation_protos
+  specs:
+    protobug_in_toto_attestation_protos (0.2.0)
+      protobug (= 0.2.0)
+      protobug_well_known_protos (= 0.2.0)
+
+PATH
+  remote: gen/protobug_protoc_gen_openapiv2_protos
+  specs:
+    protobug_protoc_gen_openapiv2_protos (0.2.0)
+      protobug (= 0.2.0)
+      protobug_googleapis_field_behavior_protos (= 0.2.0)
       protobug_well_known_protos (= 0.2.0)
 
 PATH
@@ -134,7 +166,11 @@ DEPENDENCIES
   protobug-compiler!
   protobug_compiler_protos!
   protobug_conformance_protos!
+  protobug_fulcio_protos!
+  protobug_googleapis_annotations_protos!
   protobug_googleapis_field_behavior_protos!
+  protobug_in_toto_attestation_protos!
+  protobug_protoc_gen_openapiv2_protos!
   protobug_sigstore_protos!
   protobug_well_known_protos!
   rake (~> 13.2)


### PR DESCRIPTION
The four proto gems added since the last release — `protobug_fulcio_protos`, `protobug_googleapis_annotations_protos`, `protobug_in_toto_attestation_protos`, and `protobug_protoc_gen_openapiv2_protos` — are listed in the 0.2.0 CHANGELOG but were not in the `Gemfile`. Since the release tasks publish only the `protobug*` gems present in `Bundler.definition.specs`, these would have been silently omitted from the `v0.2.0` release.

This adds all four to the `Gemfile` and updates `Gemfile.lock` (via `bundle lock`, preserving the full `PLATFORMS` list) so the release publishes the complete set of 11 gems.

🤖 Generated with [Claude Code](https://claude.com/claude-code)