### PR TITLE
Write a real README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,39 +1,116 @@
 # Protobug
 
-TODO: Delete this and the text below, and describe your gem
+A protobuf runtime and compiler for Ruby, written in plain Ruby.
 
-Welcome to your new gem! In this directory, you'll find the files you need to be able to package up your Ruby library into a gem. Put your Ruby code in the file `lib/protobug`. To experiment with that code, run `bin/console` for an interactive prompt.
+Most Ruby protobuf support leans on `google-protobuf`, which ships a C extension.
+That's fine until you need to vendor protobuf code into a library and don't want
+to drag a native dependency along with it. Protobug takes the other approach: the
+runtime is pure Ruby with no dependencies, and the compiler emits ordinary `.rb`
+files you can read, diff, and commit to your repo like any other source.
 
-## Installation
+It was written to give [sigstore-ruby](https://github.com/sigstore/sigstore-ruby)
+a protobuf implementation it could embed without forcing a native build on its
+users, but there's nothing sigstore-specific about it.
 
-TODO: Replace `UPDATE_WITH_YOUR_GEM_NAME_IMMEDIATELY_AFTER_RELEASE_TO_RUBYGEMS_ORG` with your gem name right after releasing it to RubyGems.org. Please do not do it earlier due to security reasons. Alternatively, replace this section with instructions to install your gem from git if you don't plan to release to RubyGems.org.
+## How it works
 
-Install the gem and add to the application's Gemfile by executing:
+A `protoc` plugin (`protoc-gen-protobug`) reads your `.proto` files and writes
+Ruby. The generated code is a thin DSL on top of `Protobug::Message` — each
+message is a class that declares its fields, and a registry ties related messages
+together for decoding. Field documentation from the `.proto` carries through as
+comments. Here's what comes out the other end for `google.protobuf.Duration`:
 
-    $ bundle add UPDATE_WITH_YOUR_GEM_NAME_IMMEDIATELY_AFTER_RELEASE_TO_RUBYGEMS_ORG
+```ruby
+module Google
+  module Protobuf
+    class Duration
+      extend Protobug::Message
 
-If bundler is not being used to manage dependencies, install the gem by executing:
+      self.full_name = "google.protobuf.Duration"
 
-    $ gem install UPDATE_WITH_YOUR_GEM_NAME_IMMEDIATELY_AFTER_RELEASE_TO_RUBYGEMS_ORG
+      # Signed seconds of the span of time. Must be from -315,576,000,000
+      # to +315,576,000,000 inclusive. Note: these bounds are computed from:
+      # 60 sec/min * 60 min/hr * 24 hr/day * 365.25 days/year * 10000 years
+      optional(1, "seconds", type: :int64, proto3_optional: false)
+      # Signed fractions of a second at nanosecond resolution of the span
+      # of time. Durations less than one second are represented with a 0
+      # `seconds` field and a positive or negative `nanos` field. For durations
+      # of one second or more, a non-zero value for the `nanos` field must be
+      # of the same sign as the `seconds` field. Must be from -999,999,999
+      # to +999,999,999 inclusive.
+      optional(2, "nanos", type: :int32, proto3_optional: false)
+    end
+
+    def self.register_duration_protos(registry)
+      registry.register(Google::Protobuf::Duration)
+    end
+  end
+end
+```
+
+You can write that by hand too — the generator isn't doing anything you couldn't.
 
 ## Usage
 
-TODO: Write usage instructions here
+Decoding needs a registry holding the message types that might show up (including
+any referenced by `Any` fields). Register what you need, then encode and decode:
+
+```ruby
+registry = Protobug::Registry.new do |r|
+  Sigstore::TrustRoot::V1.register_sigstore_trustroot_protos(r)
+end
+
+# from the wire format
+trusted_root = Sigstore::TrustRoot::V1::TrustedRoot.decode(io_or_string, registry: registry)
+
+# from a parsed JSON hash
+trusted_root = Sigstore::TrustRoot::V1::TrustedRoot.decode_json_hash(hash, registry: registry)
+
+# and back out
+bytes = Sigstore::TrustRoot::V1::TrustedRoot.encode(trusted_root)
+json  = trusted_root.to_json
+```
+
+Both proto2 and proto3 are supported, along with binary and JSON encodings.
+Protobug runs the upstream protobuf conformance suite; the handful of cases it
+doesn't pass yet are tracked in `conformance/failure_list.txt`.
+
+## Installation
+
+```sh
+bundle add protobug
+```
+
+The runtime gem is all you need at runtime. To generate code, you also want the
+compiler, which is a separate gem so it stays out of your production dependencies:
+
+```sh
+gem install protobug-compiler
+```
+
+Installing the gem puts a `protoc-gen-protobug` executable on your `PATH`, which
+`protoc` discovers on its own, so generating code is just:
+
+```sh
+protoc --protobug_out=lib path/to/your.proto
+```
 
 ## Development
 
-After checking out the repo, run `bin/setup` to install dependencies. Then, run `rake spec` to run the tests. You can also run `bin/console` for an interactive prompt that will allow you to experiment.
+Run `bin/setup` to install dependencies, then `rake spec` for the unit tests.
+`rake` on its own runs the full suite: specs, the example, the protobuf
+conformance runner, and rubocop. The generated protos under `gen/` are built from
+the definitions wired up in the `Rakefile`; regenerating them needs `protoc`
+installed.
 
-To install this gem onto your local machine, run `bundle exec rake install`. To release a new version, update the version number in `version.rb`, and then run `bundle exec rake release`, which will create a git tag for the version, push git commits and the created tag, and push the `.gem` file to [rubygems.org](https://rubygems.org).
+`bin/console` drops you into an IRB session with the library loaded.
 
 ## Contributing
 
-Bug reports and pull requests are welcome on GitHub at https://github.com/[USERNAME]/protobug. This project is intended to be a safe, welcoming space for collaboration, and contributors are expected to adhere to the [code of conduct](https://github.com/[USERNAME]/protobug/blob/main/CODE_OF_CONDUCT.md).
+Bug reports and pull requests are welcome at
+https://github.com/segiddins/protobug. Everyone interacting with the project is
+expected to follow the [code of conduct](CODE_OF_CONDUCT.md).
 
 ## License
 
-The gem is available as open source under the terms of the [MIT License](https://opensource.org/licenses/MIT).
-
-## Code of Conduct
-
-Everyone interacting in the Protobug project's codebases, issue trackers, chat rooms and mailing lists is expected to follow the [code of conduct](https://github.com/[USERNAME]/protobug/blob/main/CODE_OF_CONDUCT.md).
+Available under the terms of the [MIT License](LICENSE.txt).


### PR DESCRIPTION
Replaces the bundler gem-skeleton placeholder (`TODO: Delete this and describe your gem`) with actual documentation:

- **What protobug is** — a pure-Ruby protobuf runtime and compiler with no C extension, intended to be vendored without dragging a native dependency along.
- **How it works** — the `protoc-gen-protobug` plugin generates plain, readable Ruby on top of the `Protobug::Message` DSL. The example reproduces the generated `google.protobuf.Duration` verbatim.
- **Usage** — registry setup plus binary/JSON encode and decode, drawn from `example.rb`.
- **Install & development** — the two-gem split (`protobug` runtime, `protobug-compiler` build-time), `protoc` plugin auto-discovery, and the `rake` tasks.

Conformance is described against `conformance/failure_list.txt`, the hand-maintained allowlist passed to the upstream `conformance_test_runner` (not the gitignored `failing_tests.txt` run artifact).

🤖 Generated with [Claude Code](https://claude.com/claude-code)